### PR TITLE
chore(weasel): fonts fallback config

### DIFF
--- a/weasel.yaml
+++ b/weasel.yaml
@@ -54,7 +54,7 @@ style:
   # 全局字体
   # 格式：字体1:起始码位:结束码位:字重:字形,字体2……，字体会依次 fallback
   # 详细设定请参考 <https://github.com/rime/weasel/wiki/字體設定>
-  font_face: "Segoe UI Emoji:23:23, Segoe UI Emoji:2a:2a, Segoe UI Emoji:30:39, Segoe UI Emoji:fe0f:fe0f, Segoe UI Emoji:20e3:20e3, Microsoft YaHei, Segoe UI Emoji, Noto Color Emoji"
+  font_face: "Segoe UI Emoji:23:23, Segoe UI Emoji:2a:2a, Segoe UI Emoji:30:39, Segoe UI Emoji:fe0f:fe0f, Segoe UI Emoji:20e3:20e3, Segoe UI, Microsoft YaHei, DengXian, Segoe UI Emoji, Noto Color Emoji"
   label_font_face: "Microsoft YaHei"       # 标签字体
   comment_font_face: "Microsoft YaHei"     # 注释字体
   font_point: 14                           # 全局字体字号


### PR DESCRIPTION
修改字体fallback，以正确显示各种字符：

1. Weasel中优先使用微软雅黑显示≠√∞等符号，以规避Segoe UI Emoji字符映射错误。图中首行为微软雅黑，显示正确；次行为Segoe UI Emoji，显示有误：
<img width="230" height="247" alt="屏幕截图 2025-08-01 143021" src="https://github.com/user-attachments/assets/5c746c67-6395-4776-80b8-afe40ed0f3b1" />


2. 上述符号正确显示的前提下，保证*️⃣#️⃣0️⃣1️⃣2️⃣...9️⃣正常显示为emoji（图中首行）：
<img width="402" height="259" alt="屏幕截图 2025-08-01 182037" src="https://github.com/user-attachments/assets/ba2eb7c2-13af-4753-93b8-622c7aab4feb" />


- 另外对于♀♂等字符，视同Ω∑∫等符号，优先调用微软雅黑显示（图中第一行）。如需调整为其他形式（如图中第二行的Segoe UI Emoji），可自行修改配置，详细讲解参看[Weasel教程](https://github.com/rime/weasel/wiki/%E5%AD%97%E9%AB%94%E8%A8%AD%E5%AE%9A)。例子：
 `  font_face: "Segoe UI Emoji:2640:2642, Segoe UI Emoji:30:39, Segoe UI Emoji:23:23, Segoe UI Emoji:2a:2a, Segoe UI Emoji:fe0f:fe0f, Segoe UI Emoji:20e3:20e3, Microsoft YaHei, Segoe UI Emoji, Noto Color Emoji"`
<img width="228" height="262" alt="屏幕截图 2025-08-01 164240" src="https://github.com/user-attachments/assets/a8904313-a62b-4cf3-b470-12e5396d820b" />


