### PR TITLE
fix(uuid): resolve duplicate UUID generation by improving random seeding

### DIFF
--- a/lua/uuid.lua
+++ b/lua/uuid.lua
@@ -33,12 +33,12 @@ end
 local M = {}
 
 function M.init(env)
+	randomseed(os.time() + os.clock() * 1000)
 	M.uuid = env.engine.schema.config:get_string(env.name_space:gsub("^*", "")) or "uuid"
 end
 
 function M.func(input, seg, _)
 	if input == M.uuid then
-		randomseed(os.time())
 		yield_cand(seg, generate_uuid_v4())
 	end
 end


### PR DESCRIPTION
Moved math.randomseed() from the generation function to the initialization phase.
Replaced os.time() with a more precise seed (os.time + os.clock) to prevent identical sequences when calls occur within the same second.