### PR TITLE
dict(cn): 增加易错音词汇及注音

### DIFF
--- a/cn_dicts/others.dict.yaml
+++ b/cn_dicts/others.dict.yaml
@@ -437,8 +437,8 @@ sort: by_weight
 博闻强识	bo wen qiang shi
 贲临	bi lin
 贲临	ben lin
-鄱阳	po yang
-鄱阳	bo yang
+鄱阳湖	po yang hu
+鄱阳湖	bo yang hu
 倾轧	qing ya
 倾轧	qing zha
 妊娠	ren shen

--- a/lua/corrector.lua
+++ b/lua/corrector.lua
@@ -194,7 +194,7 @@ function M.init(env)
         ["yi ye bian zhou"] = { text = "一叶扁舟", comment = "一叶扁(piān)舟" },
         ["bo wen qiang shi"] = { text = "博闻强识", comment = "博闻强识(zhì)" },
         ["ben lin"] = { text = "贲临", comment = "贲(bì)临" },
-        ["bo yang"] = { text = "鄱阳", comment = "鄱(pó)阳" },
+        ["bo yang hu"] = { text = "鄱阳湖", comment = "鄱(pó)阳湖" },
         ["qing zha"] = { text = "倾轧", comment = "倾轧(yà)" },
         ["ren chen"] = { text = "妊娠", comment = "妊娠(shēn)" },
         ["xin xin xue zi"] = { text = "莘莘学子", comment = "莘(shēn)莘学子" },


### PR DESCRIPTION
- 增加常见易错词词汇及校正拼音显示
- 对于`流水淙淙`这种词汇，增加`zongzong`-->`congcong淙淙`的读音校正后，直接打`liushuizongzong`候选词第一个即流水淙淙，但不会显示读音校正。类似的还有泉水淙淙、溪水淙淙等。
    - 因此修改corrector.lua的逻辑，当候选的 pinyin 中包含某条校正的拼音键，且候选词文本中包含该校正词，就用该校正的 comment 替换注释