### PR TITLE
feat(fcitx4): 增加 Linux fcitx4 兼容模式与文档说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,17 @@
 | Android | [Trime](https://github.com/osfans/trime)（同文输入法）       | ≥ 3.2.11                          |                                                              |
 | iOS     | [Hamster](https://apps.apple.com/cn/app/%E4%BB%93%E8%BE%93%E5%85%A5%E6%B3%95/id6446617683)（仓输入法） | N/A                               | 闭源；有内购                                                 |
 | Linux   | ibus + [ibus-rime](https://github.com/rime/ibus-rime)        | librime ≥ 1.8.5 且装有 librime-lua | 部分发行版需手动安装 librime-lua                             |
+| Linux   | fcitx4 + [fcitx-rime](https://github.com/fcitx/fcitx-rime)   | 完整模式：librime ≥ 1.8.5 且装有 librime-lua | 仅支持 Linux 的 fcitx4 + fcitx-rime；配置目录为 `$HOME/.config/fcitx/rime/` |
 | Linux   | fcitx5 + [fcitx5-rime](https://github.com/fcitx/fcitx5-rime) | librime ≥ 1.8.5 且装有 librime-lua | 部分发行版需手动安装 librime-lua                             |
 | macOS   | [Squirrel](https://github.com/rime/squirrel)（鼠须管）       | ≥ 1.0.0                           | 0.16.0 - 0.18.0 版本请参考[🔗](https://github.com/iDvel/rime-ice/issues/1062) |
 | macOS   | [fcitx5-macos](https://github.com/fcitx-contrib/fcitx5-macos) | N/A                               | 支持[卷轴模式](https://github.com/iDvel/rime-ice/issues/941) |
 | Windows | [Weasel](https://github.com/rime/weasel)（小狼毫）           | ≥ 0.15.0                            | 0.14.3 可手动更新 [rime.dll](https://github.com/iDvel/rime-ice/issues/197)（但不支持彩色 emoji）<br />Weasel 当下有兼容性问题，建议安装其他输入法备用 |
 
 Linux 依赖问题的具体解释请参考 [#840](https://github.com/iDvel/rime-ice/issues/840)。
+
+> [!NOTE]
+> 本仓库中提供的 fcitx4 兼容（`others/fcitx4/`）仅支持 **Linux + fcitx4 + fcitx-rime**。
+> 不适用于 fcitx5、ibus、macOS、Windows 等其他前端或平台。
 
 雾凇拼音的部分配置可能要求更高的 librime 或者客户端版本，这些功能已在具体配置文件中注明。
 
@@ -190,6 +195,9 @@ bash rime-install <recipe_name>
 ```bash
 # 为 fictx5 安装
 rime_frontend=fcitx5-rime bash rime-install <recipe_name>
+
+# 为 fcitx4 安装
+rime_frontend=fcitx-rime bash rime-install <recipe_name>
 ```
 
 ---
@@ -298,6 +306,39 @@ patch:
 ```
 
 </details>
+
+### Linux Fcitx4
+如果您使用的是 Linux + Fcitx4，可使用仓库自带脚本自动备份并同步配置：
+
+```bash
+bash others/fcitx4/install_to_fcitx4.sh
+```
+
+如果系统较旧（例如 `librime < 1.8.5` 或缺少 `librime-lua`），可使用兼容模式（禁用 Lua 扩展功能，仅保留基础拼音/词库能力）：
+
+```bash
+bash others/fcitx4/install_to_fcitx4.sh --legacy-no-lua
+```
+
+说明：默认执行 `bash others/fcitx4/install_to_fcitx4.sh` 时，脚本会自动检测环境；若版本过旧或缺少 `librime-lua`，会自动切换到兼容模式。
+
+兼容模式（`--legacy-no-lua`）会关闭以下 Lua 扩展能力：
+- 以词定字（`[`、`]`）
+- 日期、时间、星期
+- 农历
+- UUID
+- Unicode 输入（`U` 前缀）
+- 数字、金额大写（`R` 前缀）
+- 简易计算器（`cC` 前缀）
+- 错音错字提示
+- 英文自动大写
+- v 模式 symbols 优先
+- 置顶候选项
+- 长词优先
+- 英文候选降权
+- 部件拆字辅码（`search.lua`）
+
+兼容模式仍保留：基础拼音输入、词库、`melt_eng` 英文输入、中英混输、简繁切换、Emoji、用户短语。
 
 <br>
 

--- a/others/fcitx4/install_to_fcitx4.sh
+++ b/others/fcitx4/install_to_fcitx4.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MIN_RIME_VERSION="1.8.5"
+LEGACY_NO_LUA="auto"
+
+for arg in "$@"; do
+  case "$arg" in
+    --legacy-no-lua)
+      LEGACY_NO_LUA="true"
+      ;;
+    --full)
+      LEGACY_NO_LUA="false"
+      ;;
+    *)
+      echo "未知参数: ${arg}"
+      echo "用法: $0 [--legacy-no-lua|--full]"
+      exit 1
+      ;;
+  esac
+done
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET_DIR="${HOME}/.config/fcitx/rime"
+BACKUP_BASE="${HOME}/.config/fcitx"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_DIR="${BACKUP_BASE}/rime.backup.${TIMESTAMP}"
+
+version_ge() {
+  local lhs="$1"
+  local rhs="$2"
+  [[ "$(printf '%s\n%s\n' "${lhs}" "${rhs}" | sort -V | head -n1)" == "${rhs}" ]]
+}
+
+detect_librime_version() {
+  local ver=""
+  if command -v pkg-config >/dev/null 2>&1; then
+    ver="$(pkg-config --modversion rime 2>/dev/null || true)"
+  fi
+  if [[ -z "${ver}" ]] && command -v dpkg-query >/dev/null 2>&1; then
+    ver="$(dpkg-query -W -f='${Version}' librime1 2>/dev/null || true)"
+  fi
+  echo "${ver}" | grep -Eo '[0-9]+(\.[0-9]+)+' | head -n1 || true
+}
+
+has_librime_lua() {
+  if command -v ldconfig >/dev/null 2>&1; then
+    if ldconfig -p 2>/dev/null | grep -Eiq 'librime-lua|rime[-_.]?lua'; then
+      return 0
+    fi
+  fi
+  find /usr/lib /lib -type f \( -name '*librime-lua*' -o -name '*rime*lua*' \) 2>/dev/null | head -n1 | grep -q .
+}
+
+echo "[1/4] 检查环境..."
+command -v rsync >/dev/null 2>&1 || {
+  echo "未找到 rsync，请先安装 rsync。"
+  exit 1
+}
+
+if [[ "${LEGACY_NO_LUA}" == "auto" ]]; then
+  RIME_VERSION="$(detect_librime_version)"
+  LUA_OK=false
+  if has_librime_lua; then
+    LUA_OK=true
+  fi
+
+  if [[ -z "${RIME_VERSION}" ]]; then
+    LEGACY_NO_LUA="true"
+    echo "检测不到 librime 版本，默认启用 legacy 无 Lua 兼容模式。"
+  elif ! version_ge "${RIME_VERSION}" "${MIN_RIME_VERSION}"; then
+    LEGACY_NO_LUA="true"
+    echo "检测到 librime ${RIME_VERSION} (< ${MIN_RIME_VERSION})，默认启用 legacy 无 Lua 兼容模式。"
+  elif [[ "${LUA_OK}" != "true" ]]; then
+    LEGACY_NO_LUA="true"
+    echo "未检测到 librime-lua，默认启用 legacy 无 Lua 兼容模式。"
+  else
+    LEGACY_NO_LUA="false"
+    echo "环境满足完整模式要求（librime ${RIME_VERSION}，且检测到 librime-lua）。"
+  fi
+fi
+
+mkdir -p "${TARGET_DIR}"
+
+if [[ -d "${TARGET_DIR}" ]] && [[ "$(ls -A "${TARGET_DIR}")" != "" ]]; then
+  echo "[2/4] 备份现有配置到 ${BACKUP_DIR} ..."
+  mkdir -p "${BACKUP_BASE}"
+  cp -a "${TARGET_DIR}" "${BACKUP_DIR}"
+else
+  echo "[2/4] 未检测到现有配置，跳过备份。"
+fi
+
+echo "[3/4] 同步配置到 ${TARGET_DIR} ..."
+rsync -a --delete \
+  --exclude='.git/' \
+  --exclude='.github/' \
+  --exclude='others/pages/' \
+  --exclude='others/fcitx4/' \
+  --exclude='build/' \
+  --exclude='sync/' \
+  --exclude='*.userdb/' \
+  --exclude='*.userdb/**' \
+  --exclude='user.yaml' \
+  --exclude='installation.yaml' \
+  --exclude='.place_holder' \
+  "${REPO_DIR}/" "${TARGET_DIR}/"
+
+if [[ "${LEGACY_NO_LUA}" == "true" ]]; then
+  echo "[3.5/4] 应用 legacy 无 Lua 兼容补丁 ..."
+  for name in default.custom.yaml rime_ice.custom.yaml; do
+    if [[ -f "${TARGET_DIR}/${name}" ]]; then
+      cp -a "${TARGET_DIR}/${name}" "${TARGET_DIR}/${name}.bak.${TIMESTAMP}"
+    fi
+    cp -a "${REPO_DIR}/others/fcitx4/legacy_no_lua/${name}" "${TARGET_DIR}/${name}"
+  done
+fi
+
+echo "[4/4] 尝试重载 fcitx4 ..."
+if command -v fcitx-remote >/dev/null 2>&1; then
+  fcitx-remote -r || true
+  echo "已执行：fcitx-remote -r"
+else
+  echo "未找到 fcitx-remote，请手动重启 fcitx4 后生效。"
+fi
+
+if [[ "${LEGACY_NO_LUA}" == "true" ]]; then
+  echo "完成。已启用 legacy 无 Lua 模式：仅保留基础拼音/词库能力，Lua 扩展功能已关闭。"
+else
+  echo "完成。若出现兼容性问题，请确认系统安装的是 fcitx-rime，且 librime 版本与 librime-lua 满足要求。"
+  echo "如系统较旧（例如 librime < 1.8.5 或缺少 librime-lua），请改用：bash others/fcitx4/install_to_fcitx4.sh --legacy-no-lua"
+fi

--- a/others/fcitx4/legacy_no_lua/default.custom.yaml
+++ b/others/fcitx4/legacy_no_lua/default.custom.yaml
@@ -1,0 +1,3 @@
+patch:
+  schema_list:
+    - schema: rime_ice

--- a/others/fcitx4/legacy_no_lua/rime_ice.custom.yaml
+++ b/others/fcitx4/legacy_no_lua/rime_ice.custom.yaml
@@ -1,0 +1,25 @@
+patch:
+  translator/always_show_comments: false
+  translator/spelling_hints: 0
+  translator/comment_format: []
+  engine/processors:
+    - ascii_composer
+    - recognizer
+    - key_binder
+    - speller
+    - punctuator
+    - selector
+    - navigator
+    - express_editor
+  engine/translators:
+    - punct_translator
+    - script_translator
+    - table_translator@custom_phrase
+    - table_translator@melt_eng
+    - table_translator@cn_en
+    - table_translator@radical_lookup
+  engine/filters:
+    - reverse_lookup_filter@radical_reverse_lookup
+    - simplifier@emoji
+    - simplifier@traditionalize
+    - uniquifier


### PR DESCRIPTION
## 更新说明
- 新增 Linux fcitx4 安装脚本：install_to_fcitx4.sh
- 新增老系统兼容补丁：
   - default.custom.yaml
   - rime_ice.custom.yaml
- 安装脚本支持环境自动检测：
若 librime < 1.8.5 或缺少 librime-lua，默认启用 legacy-no-lua
- 同步时保护用户运行数据，避免误删：
build/、sync/、*.userdb/、user.yaml、installation.yaml 等
- 更新 README.md：
   - 明确 fcitx4 兼容范围仅为 Linux + fcitx4 + fcitx-rime
   - 补充完整模式/兼容模式说明与使用命令
   - 补充兼容模式下禁用功能清单
## 兼容性说明
完整模式要求：librime >= 1.8.5 且安装 librime-lua
老系统自动回退兼容模式（禁用 Lua 扩展，保留基础拼音与词库能力）
## 影响范围
仅涉及 Linux fcitx4 适配路径，不影响 fcitx5/ibus/macOS/Windows 现有流程