### PR TITLE
fix: 修复时区错误显示的问题

### DIFF
--- a/lua/date_translator.lua
+++ b/lua/date_translator.lua
@@ -109,7 +109,7 @@ function M.func(input, seg, env)
 
         yield_cand(seg, string.format('%s年%s月%s日', year_0, month, day))
         yield_cand(seg, string.format('%s年%s月%s日', year_zero, month, day))
-        yield_cand(seg, os.date('%Y年%m月%d日', current_time):gsub('年0', '年'):gsub('月', '月'))
+        yield_cand(seg, os.date('%Y年%m月%d日', current_time):gsub('年0', '年'):gsub('月0', '月'))
 
         -- 英文日期
     elseif (input == M.date_en) then


### PR DESCRIPTION
## Overview

如题。使用 lua 的 `%z` 格式化日期字符串，这样就避免了硬编码东八区时间，而是可以直接从系统获取时间。

## 改进说明

修复硬编码东八区时区，导致其他时区无法正常使用 `dt` 指令的问题。

同时注意协调世界时时区是在末尾添加英文字母 `Z`。如下图。

<img width="802" height="81" alt="image" src="https://github.com/user-attachments/assets/d0bbb57f-880e-4ab3-ac0a-d47e3f249f18" />

## 注意事项

Windows 用户拉取更新后必须重启小狼毫服务器，重新部署是没有用的。

右键小狼毫图标，选择“重启算法服务”。

也可以选择使用 PowerShell。

```powershell
Stop-Process -Name WeaselServer
```

## 关闭 issue

Closes #1500 