### PR TITLE
fix: 带AM/PM时使用12小时制

### DIFF
--- a/lua/date_translator.lua
+++ b/lua/date_translator.lua
@@ -61,11 +61,11 @@ function M.func(input, seg, env)
 
         yield_cand(seg, os.date('%H:%M', current_time))
         yield_cand(seg, os.date('%H:%M:%S', current_time))
-        yield_cand(seg, period_name .. " " .. os.date("%H:%M", current_time))
-        yield_cand(seg, os.date("%H:%M %p", current_time))
+        yield_cand(seg, period_name .. " " .. os.date("%I:%M", current_time))
+        yield_cand(seg, os.date("%I:%M %p", current_time))
         -- 带上时间划分时，很少有带秒数的，暂时注释掉
-        -- yield_cand(seg, period_name .. " " .. os.date("%H:%M:%S", current_time))
-        -- yield_cand(seg, os.date("%H:%M:%S %p", current_time))
+        -- yield_cand(seg, period_name .. " " .. os.date("%I:%M:%S", current_time))
+        -- yield_cand(seg, os.date("%I:%M:%S %p", current_time))
 
         -- 星期
     elseif (input == M.week) then


### PR DESCRIPTION
不存在**20:57 PM**这种形式，24小时制本身就包含了AM还是PM。因此AM/PM时改为12小时制
<img width="150" alt="image" src="https://github.com/user-attachments/assets/ab7761e7-332e-4314-9f8c-12df534c4525" />
