### PR TITLE
fix(lua): Lua 5.5 compat for cn_en_spacer and en_spacer

### DIFF
--- a/lua/cn_en_spacer.lua
+++ b/lua/cn_en_spacer.lua
@@ -21,10 +21,11 @@ end
 
 local function cn_en_spacer(input, env)
     for cand in input:iter() do
-        if is_mixed_cn_en_num(cand.text) then
-            cand = cand:to_shadow_candidate(cand.type, add_spaces(cand.text), cand.comment)
+        local c = cand
+        if is_mixed_cn_en_num(c.text) then
+            c = c:to_shadow_candidate(c.type, add_spaces(c.text), c.comment)
         end
-        yield(cand)
+        yield(c)
     end
 end
 

--- a/lua/en_spacer.lua
+++ b/lua/en_spacer.lua
@@ -6,11 +6,12 @@ local F = {}
 function F.func( input, env )
     local latest_text = env.engine.context.commit_history:latest_text()
     for cand in input:iter() do
-        if cand.text:match( '^[%a\']+[%a\']*$' ) and latest_text and #latest_text > 0 and
+        local c = cand
+        if c.text:match( '^[%a\']+[%a\']*$' ) and latest_text and #latest_text > 0 and
             latest_text:find( '^ ?[%a\']+[%a\']*$' ) then
-            cand = cand:to_shadow_candidate( 'en_spacer', cand.text:gsub( '(%a+\'?%a*)', ' %1' ), cand.comment )
+            c = c:to_shadow_candidate( 'en_spacer', c.text:gsub( '(%a+\'?%a*)', ' %1' ), c.comment )
         end
-        yield( cand )
+        yield( c )
     end
 end
 


### PR DESCRIPTION
## Summary

Lua 5.5 treats generic `for` loop variables as `const`, so reassigning `cand` inside `for cand in input:iter() do` raises:

```
attempt to assign to const variable 'cand'
```

This causes the filters to fail to load, which cascades into breaking other lua modules (e.g. `search.lua`), ultimately resulting in **no candidate window being displayed** at all.

#1502 / #1503 fixed `search.lua` (`i = i + 1`), but the same pattern in `cn_en_spacer.lua` and `en_spacer.lua` (`cand = cand:to_shadow_candidate(...)`) was missed.

## Changes

- `cn_en_spacer.lua`: use `local c = cand` then operate on `c`
- `en_spacer.lua`: same fix

## Affected distros

Any rolling-release distro shipping Lua 5.5 (e.g. Arch, CachyOS).