### PR TITLE
conf: 添加 cn_en_spacer

### DIFF
--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -75,6 +75,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    # - lua_filter@*cn_en_spacer                      # 中英混输词条自动空格
     - lua_filter@*v_filter                          # v 模式 symbols 优先
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*long_word_filter                  # 长词优先（顺序要求：长词优先 > Emoji）


### PR DESCRIPTION
关联 https://github.com/iDvel/rime-ice/issues/327

不确定为什么这个功能没有默认启用，因此只是加条注释便于用户发现