### PR TITLE
feat: v 模式触发码提示

### DIFF
--- a/double_pinyin.schema.yaml
+++ b/double_pinyin.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置
     - simplifier@emoji                              # Emoji

--- a/double_pinyin_abc.schema.yaml
+++ b/double_pinyin_abc.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                          # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup   # 部件拆字滤镜
     - lua_filter@*autocap_filter                     # 英文自动大写
+    - lua_filter@*v_hint_filter                      # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                    # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter              # 降低部分英语单词在候选项的位置
     - simplifier@emoji                               # Emoji

--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置
     - simplifier@emoji                              # Emoji

--- a/double_pinyin_jiajia.schema.yaml
+++ b/double_pinyin_jiajia.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置
     - simplifier@emoji                              # Emoji

--- a/double_pinyin_mspy.schema.yaml
+++ b/double_pinyin_mspy.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置
     - simplifier@emoji                              # Emoji

--- a/double_pinyin_sogou.schema.yaml
+++ b/double_pinyin_sogou.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置
     - simplifier@emoji                              # Emoji

--- a/double_pinyin_ziguang.schema.yaml
+++ b/double_pinyin_ziguang.schema.yaml
@@ -86,6 +86,7 @@ engine:
     - lua_filter@*corrector                         # 错音错字提示
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置
     - simplifier@emoji                              # Emoji

--- a/lua/v_hint_filter.lua
+++ b/lua/v_hint_filter.lua
@@ -1,0 +1,28 @@
+-- 输入单字符 'v' 时，在候选首位插入一条提示候选项，列出常用的
+-- v 模式 symbols 触发码（jz 夹注 / bd 标点 / sx 数学 / jt 箭头 ...）。
+-- 帮助新用户回忆雾凇 v 模式所提供的反查类目，无需翻 symbols_v.yaml。
+--
+-- 候选项的 text 为 'v'，hint 文案放在 comment 字段（灰色辅助文）；
+-- 不会自动提交，万一被误选也只插入一个 'v'，无破坏性副作用。
+--
+-- 用 lua_filter 而非 lua_translator 的原因：librime 在短拼音段被
+-- script_translator 完整消费后会跳过后续 lua_translator；filter 在
+-- 候选流出口运行，不受该路径优化影响。
+
+local function v_hint_filter(input, env)
+    local code = env.engine.context.input
+    if code == "v" then
+        local seg = env.engine.context.composition:back()
+        if seg then
+            local hint = "jz夹注 bd标点 sx数学 jt箭头 a/o/e/i/u声调 0-10数字"
+            local cand = Candidate("v_hint", seg.start, seg._end, "v", hint)
+            cand.quality = 9999
+            yield(cand)
+        end
+    end
+    for cand in input:iter() do
+        yield(cand)
+    end
+end
+
+return v_hint_filter

--- a/rime_ice.schema.yaml
+++ b/rime_ice.schema.yaml
@@ -76,6 +76,7 @@ engine:
     - reverse_lookup_filter@radical_reverse_lookup  # 部件拆字滤镜
     - lua_filter@*autocap_filter                    # 英文自动大写
     - lua_filter@*v_filter                          # v 模式 symbols 优先
+    - lua_filter@*v_hint_filter                     # v 模式触发码提示（输入单字符 'v' 时）
     - lua_filter@*pin_cand_filter                   # 置顶候选项（顺序要求：置顶候选项 > Emoji > 简繁切换）
     - lua_filter@*long_word_filter                  # 长词优先（顺序要求：长词优先 > Emoji）
     - lua_filter@*reduce_english_filter             # 降低部分英语单词在候选项的位置


### PR DESCRIPTION
Re: #1538（提案 + 截图 + 设计抉择讨论见 issue）

## 改动

| 文件 | 改动 |
|---|---|
| `lua/v_hint_filter.lua` | 新建 filter 实现，+28 行 |
| `rime_ice.schema.yaml` | filter 列表加 1 行 |
| `double_pinyin{,_abc,_flypy,_jiajia,_mspy,_sogou,_ziguang}.schema.yaml` | filter 列表各加 1 行 |

共 9 文件，+36 / -0。

## 实现要点

走 `lua_filter` 而非 `lua_translator`。librime 在短拼音段被 `script_translator` 完整消费后会跳过后续 lua_translator —— 用 translator 写则单字符 `v` 永不触发；用 filter 在候选流出口运行更稳妥。

候选项设计：

- `text = "v"`：万一被误选也只插入字面 `v`，无破坏性副作用
- `comment` 放提示文案：灰色辅助文，不被提交
- `quality = 9999`：稳居首位

## 测试

- [x] 全拼输入单 `v` → 首位显示提示候选
- [x] 全拼输入 `vj` → 提示消失，进入 symbols 反查
- [x] 全拼输入 `vjz` / `vbd` / `vsx` 等 → 原 symbols 列表正常
- [x] 选择首项 → 仅提交字面 `v`
- [x] macOS 鼠须管 + 全拼模式下实测通过

双拼变体未亲自部署验证，但 filter 逻辑只检查 `context.input == "v"`，与方案具体规则解耦。如 maintainer 方便测一下任一双拼方案就更稳。

## 待讨论

#1538 中提到的 3 个设计抉择（默认开 vs switch / 是否含 `vy` / 是否加 T9）尚未在本 PR 落定。如 maintainer 有偏好，告诉我，我会 push 调整后的 commit。

如果方向已 OK 直接 merge 也行。